### PR TITLE
ci: migrate Docker actions to Node 24

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -36,21 +36,21 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- migrate the Docker workflow actions to their Node 24 majors
- remove the runner deprecation warnings without enabling the insecure Node 20 fallback

## Incident
The Docker workflow was failing before the build because `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` were absent. Both repository secrets have now been configured, and rerun 32836501460 completed successfully, including login, build, and push.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docker.yml`
- `npm run build`
- live Docker workflow rerun: success